### PR TITLE
Use the appropriate literal to represent octal numbers

### DIFF
--- a/lib/RemoteDirectory.js
+++ b/lib/RemoteDirectory.js
@@ -11,7 +11,7 @@ class RemoteDirectory {
     this.hostname = hostname;
   }
 
-  create(mode=0777) {
+  create(mode=0o777) {
     return;
   }
 


### PR DESCRIPTION
In the process of upgrading babel in Atom core (https://github.com/atom/atom/pull/13823) we have noticed this package uses JavaScript features that are either deprecated or that are incompatible with the language specification.

This pull request changes the code to stop using such features so that the package keeps working when the babel upgrade will be merged and released.

I have enabled edits from maintainers, so feel free to make any changes to this branch! Also, please let me know if you have any questions or concerns and if I can help somehow. Thanks!